### PR TITLE
Update AutoBrew.sh

### DIFF
--- a/AutoBrew.sh
+++ b/AutoBrew.sh
@@ -44,13 +44,13 @@ unset HOME
 unset USER
 
 # Finish up Homebrew install as target user
-sudo -u "${TargetUser}" bash -c "/usr/local/bin/brew update --force"
+su - "${TargetUser}" -c "/usr/local/bin/brew update --force"
 
 # Run cleanup before checking in with the doctor
-sudo -u "${TargetUser}" bash -c "/usr/local/bin/brew cleanup"
+su - "${TargetUser}" -c "/usr/local/bin/brew cleanup"
 
 # Check Homebrew install status
-sudo -u "${TargetUser}" bash -c "/usr/local/bin/brew doctor"
+su - "${TargetUser}" -c "/usr/local/bin/brew doctor"
 
 # Check with the doctor status to see if everything looks good
 if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
I've noticed in testing that running the update/cleanup/doctor commands using sudo -u will result in shell-init errors (shown below) 

shell-init: error retrieving current directory: getcwd: cannot access parent directories: Permission denied
shell-init: error retrieving current directory: getcwd: cannot access parent directories: Permission denied 

Using su - user , resolves these errors. I believe the "-" in "su -" resolves this, as it changes the environment to the specified user's environment, as opposed to staying in the root user's environment.