### PR TITLE
applied shellcheck fixes

### DIFF
--- a/AutoBrew.sh
+++ b/AutoBrew.sh
@@ -36,7 +36,8 @@ brew_file_paths=$(sed '1,/==> This script will install:/d;/==> /,$d' \
     "${BREW_INSTALL_LOG}")
 brew_dir_paths=$(sed '1,/==> The following new directories/d;/==> /,$d' \
     "${BREW_INSTALL_LOG}")
-chown -R "${TargetUser}":admin "${brew_file_paths}" "${brew_dir_paths}"
+# shellcheck disable=SC2086
+chown -R "${TargetUser}":admin ${brew_file_paths} ${brew_dir_paths}
 chgrp admin /usr/local/bin/
 chmod g+w /usr/local/bin
 

--- a/AutoBrew.sh
+++ b/AutoBrew.sh
@@ -2,10 +2,11 @@
 # AutoBrew - Install Homebrew with root
 # Source: https://github.com/kennyb-222/AutoBrew/
 # Author: Kenny Botelho
-# Version: 1.0
+# Version: 1.0.1
 
 # Set environment variables
-export HOME=$(mktemp -d)
+HOME="$(mktemp -d)"
+export HOME
 export USER=root
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 BREW_INSTALL_LOG=$(mktemp)
@@ -15,10 +16,10 @@ TargetUser=$(echo "show State:/Users/ConsoleUser" | \
     scutil | awk '/Name :/ && ! /loginwindow/ { print $3 }')
 
 # Check if parameter passed to use pre-defined user
-if [[ -n $3 ]]; then
+if [ -n "$3" ]; then
     # Supporting running the script in Jamf with no specialization via Self Service
     TargetUser=$3
-elif [[ -n $1 ]]; then
+elif [ -n "$1" ]; then
     # Fallback case for the command line initiated method
     TargetUser=$3
 fi
@@ -28,14 +29,14 @@ fi
     https://raw.githubusercontent.com/Homebrew/install/master/install.sh | \
     sed "s/abort \"Don't run this as root\!\"/\
     echo \"WARNING: Running as root...\"/" | \
-    sed 's/  wait_for_user/  :/')" 2>&1 | tee ${BREW_INSTALL_LOG}
+    sed 's/  wait_for_user/  :/')" 2>&1 | tee "${BREW_INSTALL_LOG}"
 
 # Reset Homebrew permissions for target user
 brew_file_paths=$(sed '1,/==> This script will install:/d;/==> /,$d' \
-    ${BREW_INSTALL_LOG})
+    "${BREW_INSTALL_LOG}")
 brew_dir_paths=$(sed '1,/==> The following new directories/d;/==> /,$d' \
-    ${BREW_INSTALL_LOG})
-chown -R "${TargetUser}":admin ${brew_file_paths} ${brew_dir_paths}
+    "${BREW_INSTALL_LOG}")
+chown -R "${TargetUser}":admin "${brew_file_paths}" "${brew_dir_paths}"
 chgrp admin /usr/local/bin/
 chmod g+w /usr/local/bin
 
@@ -49,11 +50,8 @@ su - "${TargetUser}" -c "/usr/local/bin/brew update --force"
 # Run cleanup before checking in with the doctor
 su - "${TargetUser}" -c "/usr/local/bin/brew cleanup"
 
-# Check Homebrew install status
-su - "${TargetUser}" -c "/usr/local/bin/brew doctor"
-
-# Check with the doctor status to see if everything looks good
-if [[ $? -eq 0 ]]; then
+# Check Homebrew install status, check with the doctor status to see if everything looks good
+if su - "${TargetUser}" -c "/usr/local/bin/brew doctor"; then
     echo 'Homebrew Installation Complete! Your system is ready to brew.'
     exit 0
 else


### PR DESCRIPTION
- ran shellcheck linter and applied all recommended fixes (script now passes shellcheck with no errors or warnings)
  - removed POSIX-incompatible Bashisms (e.g. double-brackets)
  - double-quoted variable strings to prevent globbing and word-splitting (except where omitting quotes was required for script functionality)
  - removed `$?` check, replaced with `if command; then` to check exit code directly
- iterated version